### PR TITLE
Existing records error handling

### DIFF
--- a/app/controllers/existing_records_controller.rb
+++ b/app/controllers/existing_records_controller.rb
@@ -53,10 +53,8 @@ class ExistingRecordsController < ApplicationController
     @existing_record.xml = request.body.read
     respond_to do |format|
       if @existing_record.save
-        puts "saved ok"
         format.xml { redirect_to action: "edit", pid: params[:pid],  notice: 'Record was successfully updated.'  }
       else
-        puts "errors"
         format.xml { render xml: edit.errors, status: :unprocessable_entity }
       end
     end

--- a/app/controllers/existing_records_controller.rb
+++ b/app/controllers/existing_records_controller.rb
@@ -6,7 +6,12 @@ class ExistingRecordsController < ApplicationController
   def edit
     @existing_record = ExistingRecord.where(pid: params[:pid]).first_or_create
     if @existing_record.xml.blank?
-      @existing_record.xml = dil_api_get_vra( params[:pid] )
+      begin
+        @existing_record.xml = dil_api_get_vra( params[:pid] )
+      rescue
+        flash[:error] = "The pid: \"#{params[:pid]}\" was not found in Repository|Images"
+        redirect_to root_path
+      end
     end
   end
 

--- a/spec/controllers/existing_records_controller_spec.rb
+++ b/spec/controllers/existing_records_controller_spec.rb
@@ -26,6 +26,16 @@ RSpec.describe ExistingRecordsController, :type => :controller do
     end
   end
 
+  describe "Gracefully handle a non-existent record" do
+    it "redirects to root path and responds with a flash error when the pid does not exist in the Images app" do
+      stub_request(:get, "http://127.0.0.1:3331/technical_metadata/non-existent-pid/VRA").
+        to_return(:status => 500)
+      post :edit, pid: "non-existent-pid"
+      expect(response).to redirect_to(root_path)
+      expect(flash[:error]).to be_present
+    end
+  end
+
   describe "Edit an existing record" do
     before do
       @controller = ExistingRecordsController.new
@@ -35,9 +45,9 @@ RSpec.describe ExistingRecordsController, :type => :controller do
     end
 
     it "gets the record's vra from Images app" do
-        @pid = "inu:dil-c5275483-699b-46de-b7ac-d4e54112cb60"
-        response = @controller.send( :dil_api_get_vra, @pid )
-        expect(response).to include("Some XML for you")
+      @pid = "inu:dil-c5275483-699b-46de-b7ac-d4e54112cb60"
+      response = @controller.send( :dil_api_get_vra, @pid )
+      expect(response).to include("Some XML for you")
     end
 
     it "lets you update an existing record" do


### PR DESCRIPTION
Fixes an issue where you get an 500 when searching for a non-existent pid for an ExistingRecord. Expected behavior is a redirect to the root route with an appropriate flash error message.

### Steps to reproduce the behavior

1. Enter a search for a known non-existent pid in the navigation bar.
2. Make sure you get redirected to the root path with a flash error.